### PR TITLE
add/update dependencies + use allowed port

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,12 +25,14 @@
     "nets": "^2.0.0",
     "ractive": "^0.6.1",
     "routes-router": "^4.1.1",
-    "sqlite-search": "^3.2.0",
+    "sqlite-search": "^4.1.0",
     "through2": "^0.6.3"
   },
   "devDependencies": {
-    "dat": "^6.9.6",
+    "dat": "^7.0.4",
     "gasket": "^2.0.0",
+    "github-url-to-object": "^1.5.2",
+    "jsonfilter": "^1.1.2",
     "parallel": "^0.2.1",
     "ractivate": "^0.2.0",
     "request": "^2.51.0",

--- a/server/test.js
+++ b/server/test.js
@@ -13,7 +13,7 @@ var searchOpts = {
 
 console.log(searchOpts)
 
-var port = 88888
+var port = 65535
 
 function startServer (t, cb) {
   createServer(searchOpts, function (err, server) {


### PR DESCRIPTION
Hello! This:
- updates sqlite-search to 4.x - (support for [`formatType = 'object'`](https://github.com/maxogden/npm-readme-search/blob/9410c6a8aaebdde59019b4dc1eca10361ab8d04c/server/server.js#L23) came [after 3.x](https://github.com/maxogden/sqlite-search/commits/228445776f6e730826f68aeef22f6cf42d86fa7e))
- updates dat to [7.x so that the registry endpoint can be accessed](https://github.com/maxogden/dat/issues/353#issuecomment-126048361)
- adds jsonfilter as a devDep (used by `gasket.index`)
- adds github-url-to-object as a devDep (used by `/import.js`)
- changes the server/test.js port to `65535` to avoid an error:
  
  ```
  > npm test
  
  > npm-app@1.0.0 test /Users/stephen/dev/npm-readme-search
  > node server/test.js
  
  { path: '/Users/stephen/dev/npm-readme-search/npm-readmes.sqlite',
  primaryKey: 'name',
  columns: [ 'name', 'readme' ] }
  TAP version 13
  # can search through api
  ok 1 undefined
  net.js:917
    throw new RangeError('port should be >= 0 and < 65536: ' +
          ^
  RangeError: port should be >= 0 and < 65536: 88888
  at Socket.connect (net.js:917:13)
  at Agent.exports.connect.exports.createConnection (net.js:92:35)
  at Agent.createSocket (_http_agent.js:194:16)
  at Agent.addRequest (_http_agent.js:166:23)
  at new ClientRequest (_http_client.js:154:16)
  at Object.exports.request (http.js:49:10)
  at Request.start (/Users/stephen/dev/npm-readme-search/node_modules/request/request.js:803:30)
  at Request.end (/Users/stephen/dev/npm-readme-search/node_modules/request/request.js:1386:10)
  at end (/Users/stephen/dev/npm-readme-search/node_modules/request/request.js:574:14)
  at Immediate._onImmediate (/Users/stephen/dev/npm-readme-search/node_modules/request/request.js:588:7)
  ```
